### PR TITLE
Styling tweak: Fix background color for code blocks inside doc callouts

### DIFF
--- a/pages/docs/pageStyle.module.css
+++ b/pages/docs/pageStyle.module.css
@@ -490,6 +490,10 @@
   > *:last-child {
     margin-bottom: 0;
   }
+
+  code {
+    background-color: unset;
+  }
 }
 
 .docCallout--neutral,


### PR DESCRIPTION
Simple fix.

Before:
